### PR TITLE
remove git diff from entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,12 +87,6 @@ main() {
 
   enable_expanded_output
 
-  echo 'Running git diff'
-  if ! git diff --exit-code --quiet --cached; then
-    echo Aborting due to uncommitted changes in the index >&2
-    return 1
-  fi
-
   commit_title=`git log -n 1 --format="%s" HEAD`
   echo "The commit title: ${commit_title}"
   commit_hash=` git log -n 1 --format="%H" HEAD`


### PR DESCRIPTION
Remove git diff from entrypoint.sh to fix Publish to Docs github action
See: 
https://github.com/zooniverse/panoptes/actions/runs/4450858532/jobs/7816816410
https://stackoverflow.com/questions/69470009/git-diff-cached-unknown-option-cached