### PR TITLE
Revert "remove git diff from entrypoint"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,6 +91,12 @@ main() {
 
   enable_expanded_output
 
+  echo 'Running git diff'
+  if ! git diff --exit-code --quiet --cached; then
+    echo Aborting due to uncommitted changes in the index >&2
+    return 1
+  fi
+
   commit_title=`git log -n 1 --format="%s" HEAD`
   echo "The commit title: ${commit_title}"
   commit_hash=` git log -n 1 --format="%H" HEAD`


### PR DESCRIPTION
Reverts zooniverse/middleman-gh-pages-action#3

the underlying issue was with the git directory ownership mismatch between runner and container and a change to fix a CVE in git. So we can revert this removal and get the workflow running properly again. 

Details in #4 